### PR TITLE
fix: allow product submission for personal accounts (#21)

### DIFF
--- a/lib/products/product-actions.ts
+++ b/lib/products/product-actions.ts
@@ -15,10 +15,10 @@ export const addProductAction = async (
     try {
         const { userId, orgId } = await auth();
 
-        if (!userId || !orgId) {
+        if (!userId) {
             return {
                 success: false,
-                message: "You must be signed in and part of an organization.",
+                message: "You must be signed in to submit a product.",
             };
         }
 


### PR DESCRIPTION
- Modified addProductAction to only require userId
- Updated auth check message to reflect that organizations are optional
- Enabled personal account users (non-org) to submit products successfully