### PR TITLE
feat: improve product submission UX with split-layout and skeletons

### DIFF
--- a/app/submit/loading.tsx
+++ b/app/submit/loading.tsx
@@ -1,0 +1,57 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function SubmitLoading() {
+  return (
+    <div className="max-w-7xl mx-auto px-4 pt-28 md:pt-22 pb-20 animate-pulse">
+      <div className="grid grid-cols-1 lg:grid-cols-[0.9fr_1.1fr] gap-12 lg:gap-20 items-start">
+        {/* Left Side Skeleton */}
+        <div>
+          <div className="mb-8 flex items-center gap-3">
+            <div className="size-10 rounded-xl bg-foreground/10 border-2 border-foreground/5" />
+            <Skeleton className="h-4 w-24 bg-foreground/10" />
+          </div>
+          <div className="space-y-4">
+            <Skeleton className="h-14 w-full bg-foreground/20 rounded-2xl" />
+            <Skeleton className="h-14 w-2/3 bg-foreground/20 rounded-2xl" />
+            <Skeleton className="h-4 w-3/4 bg-foreground/10 mt-6" />
+          </div>
+          <div className="flex gap-4 mt-12">
+            <Skeleton className="h-24 w-32 bg-foreground/5 rounded-2xl border-2 border-foreground/5" />
+            <Skeleton className="h-24 w-32 bg-foreground/5 rounded-2xl border-2 border-foreground/5" />
+          </div>
+        </div>
+
+        {/* Right Side Form Skeleton */}
+        <div className="bg-background border-[3px] border-foreground/10 rounded-[32px] p-8 md:p-10 shadow-[10px_10px_0px_0px_rgba(0,0,0,0.05)] space-y-8">
+          <div className="grid grid-cols-2 gap-6">
+            <div className="space-y-2">
+              <Skeleton className="h-3 w-12 bg-foreground/10" />
+              <Skeleton className="h-12 w-full bg-foreground/5 rounded-xl" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-3 w-12 bg-foreground/10" />
+              <Skeleton className="h-12 w-full bg-foreground/5 rounded-xl" />
+            </div>
+          </div>
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="space-y-2">
+              <Skeleton className="h-3 w-20 bg-foreground/10" />
+              <Skeleton className="h-12 w-full bg-foreground/5 rounded-xl" />
+            </div>
+          ))}
+          <div className="space-y-2">
+            <Skeleton className="h-3 w-20 bg-foreground/10" />
+            <Skeleton className="h-32 w-full bg-foreground/5 rounded-xl" />
+          </div>
+          <div className="pt-6 flex justify-between items-center">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-24 bg-foreground/10" />
+              <Skeleton className="h-3 w-32 bg-foreground/5" />
+            </div>
+            <Skeleton className="h-14 w-48 bg-foreground/20 rounded-2xl" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/submit/page.tsx
+++ b/app/submit/page.tsx
@@ -1,61 +1,56 @@
 import type { Metadata } from "next";
-import { Suspense } from "react";
 import SubmitContent from "./submit-content";
+import { Suspense } from "react";
+import SubmitLoading from "./loading";
 
 export const metadata: Metadata = {
-    title: "Launch Your Project",
-
+  title: "Launch Your Project",
+  description:
+    "Submit your startup, AI tool, side project, SaaS, developer product, or experiment to Atlash. Share what you've built, get discovered by builders, and showcase your work to the community.",
+  keywords: [
+    "submit startup",
+    "launch product",
+    "share side project",
+    "developer showcase",
+    "product launch platform",
+    "AI tools directory",
+    "startup showcase",
+    "indie hackers",
+    "maker community",
+    "developer products",
+    "software showcase",
+    "SaaS launch",
+    "product discovery",
+    "build in public",
+    "startup community",
+    "launch your startup",
+    "share your project",
+    "tech products",
+    "founder community",
+    "Atlash",
+  ],
+  openGraph: {
+    title: "Launch Your Project | Atlash Hub",
     description:
-        "Submit your startup, AI tool, side project, SaaS, developer product, or experiment to Atlash. Share what you've built, get discovered by builders, and showcase your work to the community.",
-
-    keywords: [
-        "submit startup",
-        "launch product",
-        "share side project",
-        "developer showcase",
-        "product launch platform",
-        "AI tools directory",
-        "startup showcase",
-        "indie hackers",
-        "maker community",
-        "developer products",
-        "software showcase",
-        "SaaS launch",
-        "product discovery",
-        "build in public",
-        "startup community",
-        "launch your startup",
-        "share your project",
-        "tech products",
-        "founder community",
-        "Atlash",
-    ],
-
-    openGraph: {
-        title: "Launch Your Project | Atlash Hub",
-        description:
-            "Share your startup, side project, AI tool, or developer product with builders worldwide and get discovered.",
-        type: "website",
-    },
-
-    twitter: {
-        card: "summary_large_image",
-        title: "Launch Your Project | Atlash Hub",
-        description:
-            "Submit your product, share your story, and get discovered by the builder community.",
-    },
+      "Share your startup, side project, AI tool, or developer product with builders worldwide and get discovered.",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Launch Your Project | Atlash Hub",
+    description:
+      "Submit your product, share your story, and get discovered by the builder community.",
+  },
 };
 
 export default function SubmitPage() {
-    return (
-        <section className="py-16 lg:py-24 bg-background">
-            <div className="wrapper">
-                <div className="max-w-3xl mx-auto">
-                    <Suspense fallback={<div>Loading...</div>}>
-                        <SubmitContent />
-                    </Suspense>
-                </div>
-            </div>
-        </section>
-    );
+  return (
+    <section className="py-10 lg:py-16 bg-background">
+      <div className="wrapper">
+        <Suspense fallback={<SubmitLoading />}>
+          <SubmitContent />
+        </Suspense>
+      </div>
+    </section>
+  );
 }

--- a/components/products/product-submit-form.tsx
+++ b/components/products/product-submit-form.tsx
@@ -10,269 +10,184 @@ import { toast } from "sonner";
 import Link from "next/link";
 
 const initialState: FormState = {
-    success: false,
-    errors: undefined,
-    message: "",
+  success: false,
+  errors: undefined,
+  message: "",
 };
 
 export default function ProductSubmitForm() {
-    const [state, formAction, isPending] = useActionState(
-        addProductAction,
-        initialState,
-    );
+  const [state, formAction, isPending] = useActionState(
+    addProductAction,
+    initialState,
+  );
 
-    const { errors, success } = state;
+  const { errors, success } = state;
 
-    useEffect(() => {
-        if (success) {
-            toast.success("Product submitted successfully", {
-                description:
-                    "Your project is now under review and will appear after approval.",
-                duration: 5000,
-            });
-        }
-    }, [success]);
+  useEffect(() => {
+    if (success) {
+      toast.success("Product submitted successfully", {
+        description: "Your project is now under review.",
+        duration: 5000,
+      });
+    }
+  }, [success]);
 
-    const getFieldErrors = (fieldName: string): string[] => {
-        if (!errors) return [];
-        return (errors as Record<string, string[]>)[fieldName] ?? [];
-    };
+  const getFieldErrors = (fieldName: string): string[] => {
+    if (!errors) return [];
+    return (errors as Record<string, string[]>)[fieldName] ?? [];
+  };
 
-    return (
-        <div className="max-w-5xl mx-auto px-4 pt-10 pb-20">
-            {/* back */}
-            <div className="mb-8">
-                <Link href="/" className="inline-flex items-center gap-3 group">
-                    <div
-                        className="
-                        p-2
-                        rounded-xl
-                        bg-[#FFB38A]
-                        border-2
-                        border-black
-                        shadow-[3px_3px_0px_0px_#000]
-                        transition-all
-                        group-hover:shadow-none
-                        group-hover:translate-x-[2px]
-                        group-hover:translate-y-[2px]
-                    ">
-                        <ChevronLeft className="size-4" />
-                    </div>
+  return (
+    <div className="max-w-7xl mx-auto pt-28 md:pt-22 pb-20">
+      <div className="grid grid-cols-1 lg:grid-cols-[0.9fr_1.1fr] gap-12 lg:gap-20 items-start">
+        {/* LEFT SIDE: Content & Info */}
+        <div className="lg:sticky lg:top-10">
+          <div className="mb-8">
+            <Link href="/" className="inline-flex items-center gap-3 group">
+              <div className="p-2 rounded-xl bg-[#FFB38A] border-2 border-black shadow-[3px_3px_0px_0px_#000] transition-all group-hover:shadow-none group-hover:translate-x-[2px] group-hover:translate-y-[2px]">
+                <ChevronLeft className="size-4" />
+              </div>
+              <span className="font-black text-black/60 group-hover:text-black">
+                back home
+              </span>
+            </Link>
+          </div>
 
-                    <span className="font-black text-black/60 group-hover:text-black">
-                        back home
-                    </span>
-                </Link>
+          <header className="space-y-6">
+            <h1 className="text-5xl lg:text-6xl font-black leading-[0.9] tracking-tight">
+              Share what you&apos;ve
+              <span className="relative inline-block mx-4 group">
+                {/* Decorative shadow layer */}
+                <span className="absolute inset-0 bg-black rounded-2xl translate-x-2 translate-y-2 opacity-20 group-hover:translate-x-1 group-hover:translate-y-1 transition-all"></span>
+                {/* Main Badge */}
+                <span className="relative block px-6 py-2 bg-[#FFB38A] border-[3px] border-black rounded-2xl -rotate-3 text-white italic shadow-[5px_5px_0px_0px_#000] group-hover:rotate-0 transition-transform cursor-default">
+                  built
+                </span>
+              </span>
+              with the community.
+            </h1>
+            <p className="text-xl text-black/65 font-medium leading-relaxed max-w-lg">
+              Launch your startup, AI tool, or experiment and get discovered by
+              builders worldwide.
+            </p>
+          </header>
+
+          {/* Stats Cards */}
+          <div className="flex gap-4 mt-10">
+            <div className="bg-white border-2 border-black rounded-2xl px-6 py-4 shadow-[4px_4px_0px_0px_#000]">
+              <div className="flex gap-2 items-center mb-1 opacity-60">
+                <Rocket className="size-4" />
+                <span className="text-[10px] font-black uppercase tracking-wider">
+                  launches
+                </span>
+              </div>
+              <p className="text-3xl font-black">500+</p>
+            </div>
+            <div className="bg-white border-2 border-black rounded-2xl px-6 py-4 shadow-[4px_4px_0px_0px_#000]">
+              <div className="flex gap-2 items-center mb-1 opacity-60">
+                <Users className="size-4" />
+                <span className="text-[10px] font-black uppercase tracking-wider">
+                  makers
+                </span>
+              </div>
+              <p className="text-3xl font-black">2k+</p>
+            </div>
+          </div>
+        </div>
+
+        {/* RIGHT SIDE: The Form */}
+        <form
+          action={formAction}
+          className="bg-white border-[3px] border-black rounded-[32px] p-8 md:p-10 shadow-[10px_10px_0px_0px_#000] space-y-7">
+          <div className="space-y-6">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              <FormField
+                label="name"
+                name="name"
+                id="name"
+                placeholder="Linear"
+                required
+                onChange={() => {}}
+                error={getFieldErrors("name")}
+              />
+              <FormField
+                label="slug"
+                name="slug"
+                id="slug"
+                placeholder="linear"
+                required
+                onChange={() => {}}
+                error={getFieldErrors("slug")}
+              />
             </div>
 
-            {/* hero */}
-            <section className="mb-12">
-                <h1
-                    className="
-                    text-[clamp(2.2rem,5vw,4rem)]
-                    font-black
-                    leading-[0.95]
-                    tracking-tight
-                    max-w-4xl
-                ">
-                    Share what you&apos;ve
-                    <span
-                        className="
-                        inline-block
-                        mx-3
-                        px-5
-                        py-1
-                        bg-[#FFB38A]
-                        border-4
-                        border-black
-                        rounded-2xl
-                        shadow-[5px_5px_0px_0px_#000]
-                        -rotate-2
-                        text-white
-                        italic
-                    ">
-                        built
-                    </span>
-                    with the community.
-                </h1>
+            <FormField
+              label="website"
+              name="websiteUrl"
+              id="websiteUrl"
+              placeholder="https://linear.app"
+              required
+              onChange={() => {}}
+              error={getFieldErrors("websiteUrl")}
+            />
+            <FormField
+              label="short intro"
+              name="tagline"
+              id="tagline"
+              placeholder="Issue tracking you'll enjoy using"
+              required
+              onChange={() => {}}
+              error={getFieldErrors("tagline")}
+            />
+            <FormField
+              label="tags"
+              name="tags"
+              id="tags"
+              placeholder="saas, productivity, developer-tools"
+              required
+              onChange={() => {}}
+              error={getFieldErrors("tags")}
+            />
+            <FormField
+              label="full story"
+              name="description"
+              id="description"
+              placeholder="Tell the community what you built..."
+              required
+              onChange={() => {}}
+              error={getFieldErrors("description")}
+              textarea
+            />
+          </div>
 
-                <p
-                    className="
-                    mt-5
-                    text-lg
-                    text-black/65
-                    max-w-2xl
-                    font-medium
-                    leading-relaxed
-                ">
-                    Launch your startup, side project, AI tool, developer
-                    product or experiment and get discovered by builders
-                    worldwide.
-                </p>
+          <div className="border-t-2 border-black/5 pt-8 flex flex-col sm:flex-row justify-between items-center gap-6">
+            <div className="text-center sm:text-left">
+              <p className="font-black text-sm">Ready to launch?</p>
+              <p className="text-xs text-black/50">
+                Your submission will be reviewed first.
+              </p>
+            </div>
 
-                {/* stats */}
-                <div className="flex flex-wrap gap-4 mt-8">
-                    <div
-                        className="
-                        bg-white
-                        border-2
-                        border-black
-                        rounded-2xl
-                        px-5
-                        py-4
-                        shadow-[4px_4px_0px_0px_#000]
-                    ">
-                        <div className="flex gap-2 items-center mb-1">
-                            <Rocket className="size-4" />
-                            <span className="text-xs font-black uppercase">
-                                launches
-                            </span>
-                        </div>
-
-                        <p className="text-3xl font-black">500+</p>
-                    </div>
-
-                    <div
-                        className="
-                        bg-white
-                        border-2
-                        border-black
-                        rounded-2xl
-                        px-5
-                        py-4
-                        shadow-[4px_4px_0px_0px_#000]
-                    ">
-                        <div className="flex gap-2 items-center mb-1">
-                            <Users className="size-4" />
-                            <span className="text-xs font-black uppercase">
-                                makers
-                            </span>
-                        </div>
-
-                        <p className="text-3xl font-black">2k+</p>
-                    </div>
-                </div>
-            </section>
-
-            {/* form */}
-            <form
-                action={formAction}
-                className="
-                    bg-white
-                    border-2
-                    border-black
-                    rounded-[28px]
-                    p-8
-                    md:p-10
-                    shadow-[8px_8px_0px_0px_#000]
-                    space-y-8
-                ">
-                <div className="grid md:grid-cols-2 gap-8">
-                    <FormField
-                        label="name"
-                        name="name"
-                        id="name"
-                        placeholder="Linear"
-                        required
-                        onChange={() => {}}
-                        error={getFieldErrors("name")}
-                    />
-
-                    <FormField
-                        label="website"
-                        name="websiteUrl"
-                        id="websiteUrl"
-                        placeholder="https://linear.app"
-                        required
-                        onChange={() => {}}
-                        error={getFieldErrors("websiteUrl")}
-                    />
-
-                    <FormField
-                        label="slug"
-                        name="slug"
-                        id="slug"
-                        placeholder="linear"
-                        required
-                        onChange={() => {}}
-                        error={getFieldErrors("slug")}
-                    />
-
-                    <FormField
-                        label="short intro"
-                        name="tagline"
-                        id="tagline"
-                        placeholder="Issue tracking you'll enjoy using"
-                        required
-                        onChange={() => {}}
-                        error={getFieldErrors("tagline")}
-                    />
-
-                    <div className="md:col-span-2">
-                        <FormField
-                            label="tags"
-                            name="tags"
-                            id="tags"
-                            placeholder="saas, productivity, developer-tools"
-                            required
-                            onChange={() => {}}
-                            error={getFieldErrors("tags")}
-                        />
-                    </div>
-
-                    <div className="md:col-span-2">
-                        <FormField
-                            label="full story"
-                            name="description"
-                            id="description"
-                            placeholder="Tell the community what you built, why you built it and who it's for..."
-                            required
-                            onChange={() => {}}
-                            error={getFieldErrors("description")}
-                            textarea
-                        />
-                    </div>
-                </div>
-
-                <div
-                    className="
-                    border-t
-                    border-black/10
-                    pt-8
-                    flex
-                    justify-between
-                    items-center
-                    gap-6
-                    flex-wrap
-                ">
-                    <div>
-                        <p className="font-black text-sm">Ready to launch?</p>
-
-                        <p className="text-sm text-black/50">
-                            Your submission will be reviewed first.
-                        </p>
-                    </div>
-
-                    <Button
-                        type="submit"
-                        disabled={isPending}
-                        size="lg"
-                        className="
+            <Button
+              type="submit"
+              disabled={isPending}
+              size="lg"
+              className="
                             min-w-[220px]
                             text-base
                             font-black
                         ">
-                        {isPending ? (
-                            <Loader2 className="size-5 animate-spin" />
-                        ) : (
-                            <>
-                                <Rocket className="mr-2 size-5" />
-                                Launch Project
-                            </>
-                        )}
-                    </Button>
-                </div>
-            </form>
-        </div>
-    );
+              {isPending ? (
+                <Loader2 className="size-5 animate-spin" />
+              ) : (
+                <>
+                  <Rocket className="mr-2 size-5" /> Launch Project
+                </>
+              )}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
I’ve updated the submit page to make it feel more like a tool and less like a landing page. I moved the form into a side-by-side layout so it's visible right away without having to scroll down. I also added a proper loading skeleton to replace the plain text we had before, and fixed the minor TypeScript errors in the form fields.

Closes #43